### PR TITLE
エアフェンス修正、確認用エアフェンス追加、ゴールオブジェクトがスタート付近にあったので最後の方に移動※確認

### DIFF
--- a/Speed Star/Assets/Font/light/Result_SDF.asset
+++ b/Speed Star/Assets/Font/light/Result_SDF.asset
@@ -2640,7 +2640,7 @@ Material:
     - _GlowOuter: 0.05
     - _GlowPower: 0.75
     - _GradientScale: 6
-    - _LightAngle: 2.799998
+    - _LightAngle: 0.02
     - _MaskSoftnessX: 0
     - _MaskSoftnessY: 0
     - _OutlineSoftness: 0

--- a/Speed Star/Assets/Images/プレイ画面/Materials/ShibuyaMaterials.mat
+++ b/Speed Star/Assets/Images/プレイ画面/Materials/ShibuyaMaterials.mat
@@ -42,7 +42,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 4f5b3aac5cf21d04d958e868b771c628, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.13734749, y: 0}
+        m_Offset: {x: 2.7286136, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/Speed Star/Assets/Resources/Prefabs/AirFenceEvent.prefab
+++ b/Speed Star/Assets/Resources/Prefabs/AirFenceEvent.prefab
@@ -31,7 +31,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_Children: []
   m_Father: {fileID: 3580193602506053272}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3580193601261919201
 MeshFilter:
@@ -91,97 +91,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &3580193601893526174
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3580193601893526170}
-  - component: {fileID: 3580193601893526169}
-  - component: {fileID: 3580193601893526168}
-  - component: {fileID: 3580193601893526175}
-  m_Layer: 0
-  m_Name: AirFence
-  m_TagString: AirFence
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &3580193601893526170
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3580193601893526174}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 10, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.25, z: 2}
-  m_Children: []
-  m_Father: {fileID: 3580193602506053272}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3580193601893526169
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3580193601893526174}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &3580193601893526168
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3580193601893526174}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 195f772299a7ec64c9b87cf87b59f9ec, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!65 &3580193601893526175
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3580193601893526174}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3580193602431965254
 GameObject:
   m_ObjectHideFlags: 0
@@ -208,13 +117,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3580193602431965254}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 10, y: 0, z: 0}
+  m_LocalPosition: {x: 14.84, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.5, z: 1}
   m_Children:
   - {fileID: 3580193602372946936}
   - {fileID: 3580193601712460020}
   m_Father: {fileID: 3580193602506053272}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &3580193602431965248
 BoxCollider:
@@ -268,12 +177,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3580193602506053279}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 350, y: 14, z: 0}
+  m_LocalPosition: {x: 340.98, y: 14, z: 0}
   m_LocalScale: {x: 1.5, y: 2, z: 1}
   m_Children:
-  - {fileID: 3580193601893526170}
   - {fileID: 3580193601261919206}
   - {fileID: 3580193602431965255}
+  - {fileID: 7213152446035356955}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -288,7 +197,51 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 20, y: 4, z: 1}
+  m_Size: {x: 1, y: 4, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7640023971462577996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7213152446035356955}
+  - component: {fileID: 250784198917462083}
+  m_Layer: 0
+  m_Name: AirFenceJumpPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7213152446035356955
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7640023971462577996}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10, y: -1.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3580193602506053272}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &250784198917462083
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7640023971462577996}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &3580193601712589428
 PrefabInstance:
@@ -392,11 +345,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: b2e65acdf47b79e4dab2a21e5e314077, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: b2e65acdf47b79e4dab2a21e5e314077, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: b2e65acdf47b79e4dab2a21e5e314077, type: 3}
       propertyPath: m_LocalRotation.x

--- a/Speed Star/Assets/Scenes/Sibuya.unity
+++ b/Speed Star/Assets/Scenes/Sibuya.unity
@@ -451,6 +451,90 @@ Transform:
   m_Father: {fileID: 50757406}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &103345461
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3580193602506053279, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_Name
+      value: AirFenceEvent (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 363.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193601261919206, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3580193602431965255, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.719985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7213152446035356955, guid: cfda539c9b04d66419c093003300f89f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.079984
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cfda539c9b04d66419c093003300f89f, type: 3}
 --- !u!1 &165114566
 GameObject:
   m_ObjectHideFlags: 0
@@ -1550,7 +1634,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 875026032}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 15.46, y: 2, z: 0}
+  m_LocalPosition: {x: 520, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 2}
   m_Children: []
   m_Father: {fileID: 0}
@@ -3729,7 +3813,7 @@ PrefabInstance:
     - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 350
+      value: 324.8
       objectReference: {fileID: 0}
     - target: {fileID: 3580193602506053272, guid: cfda539c9b04d66419c093003300f89f,
         type: 3}

--- a/Speed Star/Assets/Scripts/GameManager.cs
+++ b/Speed Star/Assets/Scripts/GameManager.cs
@@ -145,9 +145,6 @@ public class GameManager : MonoBehaviour
     int c = 0;
     public IEnumerator AirMark(float time)
     {
-        c += 1;
-        if (c == 1)
-        {
             for (int i = 0; i <= 2; i++)
             {
                 AudioManeger.SoundSE(AudioManeger.SE.TrikcCountdownSE);
@@ -156,6 +153,6 @@ public class GameManager : MonoBehaviour
                 airFenceMark.SetActive(false);
                 yield return new WaitForSeconds(time);
             }
-        }
+        
     }
 }

--- a/Speed Star/Assets/Scripts/Player.cs
+++ b/Speed Star/Assets/Scripts/Player.cs
@@ -26,6 +26,7 @@ public class Player : MonoBehaviour
     Vector3 airTarget;                                     //エアフェンス着地点
     Vector3 FirstPos;                                      //計算用の変数
     Vector3 PlyPos;
+    Vector3 AirPos;
 
     bool isGrounded = true;                            //床についてるかどうかの判定
     bool isJumping = false;                             //ジャンプ中かどうかの判定
@@ -98,7 +99,6 @@ public class Player : MonoBehaviour
             FirstPos = airOffset - PlyPos;
             StartCoroutine(AirFenceJump(PlyPos, FirstPos,0.3f));
             isAirTiming = false;
-            airTime = 0;
         }
         animator.SetBool("isJump", isJumping);
     }
@@ -150,12 +150,13 @@ public class Player : MonoBehaviour
         }
         //エアフェンスまでの処理を始める　制作山藤
         if (other.tag == "AirFenceEvent") {
-            airOffset = other.transform.GetChild(0).transform.position;
-            airTarget = other.transform.GetChild(1).transform.position - airOffset;
+            airOffset = other.transform.GetChild(1).transform.position;
+            airTarget = other.transform.GetChild(0).transform.position - airOffset;
+            AirPos = other.transform.GetChild(2).transform.position;
             isAir = true;
-            float MarkCountTime = -0.005f * moveSpeed + 0.3f;
-            JumpTiming = MarkCountTime * 4;
-            JumpFinish = MarkCountTime * 7;
+            float MarkCountTime = ((AirPos.x - transform.position.x) / moveSpeed) / 6 ;
+            JumpTiming = MarkCountTime * 5;
+            JumpFinish = MarkCountTime * 10;
             StartCoroutine(gameManager.AirMark(MarkCountTime));
         }
 
@@ -164,6 +165,7 @@ public class Player : MonoBehaviour
         if (other.tag == "AirFence" && isAirJump == true) {
             StartCoroutine(AirFenceJump(airOffset, airTarget,0.7f));
             isAirJump = false;
+            airTime = 0;
         }
         if (other.tag == "AirFencePos")
         {


### PR DESCRIPTION
エアフェンス修正、Player,GameManeger
Player Markが点滅する秒数を求める式変更,GameManeger AirMarkに書いてあったc += 1を削除
渋谷シーンにエアフェンスを追加、場所は一つ目が置いてあるレーンの近く
ゴールオブジェクトの移動、Goalのtagがついたオブジェクトがスタート付近にあったため
最後の方へ移動　※確認